### PR TITLE
Improve NoteEditor cursor handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
-This project contains a minimal note-taking application written with [Textual](https://textual.textualize.io/). The interface lets you type notes in a `TextArea` while an optional countdown timer can help manage your time.
+This project contains a minimal note-taking application written with [Textual](https://textual.textualize.io/). Notes are edited using a custom `NoteEditor` built on top of *prompt_toolkit* which now performs word wrapping and keeps application shortcuts available even when the editor has focus. An optional countdown timer can help manage your time.
 All interface labels and notifications are in Danish for localization.
 
 ## Usage
 
-1. Install dependencies with `pip install textual`.
-2. Run the app using `python main.py`.
+1. Install dependencies with `pip install textual prompt_toolkit`.
+2. From the project folder run the app using `python main.py`.
 3. Create additional tabs with `Ctrl+N` or open an existing file with `Ctrl+O`.
    Close the active tab with `Ctrl+W` and hide/show the tab bar with `Ctrl+B`.
    Switch between tabs by clicking the labels or pressing `Ctrl+PageUp`/`Ctrl+PageDown`.
@@ -39,5 +39,4 @@ Default shortcuts for `Ctrl+H`, `Ctrl+K` and `Ctrl+M` are disabled with high pri
 
 All styling can be changed in `style.css`. The default sheet now uses muted
 earth tones with a dusty green timer bar. Notification messages slide up from the
-bottom and fade away after a short delay. Adjust the palette and animations in
-the CSS as you see fit.
+bottom and fade away after a short delay. Adjust the palette and animations inthe CSS as you see fit.

--- a/main.py
+++ b/main.py
@@ -18,26 +18,41 @@
 import re
 import time
 import random
+import os
+import sys
+
+# Ensure custom modules in the same directory can be imported when running the script
+sys.path.insert(0, os.path.dirname(__file__))
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from textual.app import App, ComposeResult
-from textual.binding import Binding
-from textual.containers import Container, Vertical
-from textual.message import Message
-from textual.reactive import reactive
-from textual import events
-from textual.widgets import (
-    Input,
-    Static,
-    TextArea,
-    TabbedContent,
-    TabPane,
-    OptionList,
-    Button,
-)
-from textual.widgets.option_list import Option
+try:
+    from textual.app import App, ComposeResult
+    from textual.binding import Binding
+    from textual.containers import Container, Vertical
+    from textual.message import Message
+    from textual.reactive import reactive
+    from textual import events
+    from textual.widgets import (
+        Input,
+        Static,
+        TabbedContent,
+        TabPane,
+        OptionList,
+        Button,
+    )
+    from textual.widgets.option_list import Option
+except ModuleNotFoundError as exc:
+    raise SystemExit("This application requires the 'textual' package."
+                     " Install it with 'pip install textual' and try again.") from exc
+
+try:
+    from prompt_editor import NoteEditor
+except ModuleNotFoundError as exc:
+    raise SystemExit(
+        "This application requires the local module 'prompt_editor.py'."
+    ) from exc
 
 # Initial note files stored on disk. ``Path`` works across operating systems
 # and makes future modifications easy. These are loaded on startup.
@@ -148,48 +163,7 @@ class NoteInput(Input):
     ]
 
 
-class NoteTextArea(TextArea):
-    # Text area widget with custom key bindings.
 
-    # Like ``NoteInput`` remove bindings for Ctrl+H, Ctrl+K and Ctrl+M. This
-    # prevents them from triggering delete or other commands that might
-    # conflict with the application's own shortcuts. All other default
-    # behaviour is left intact.
-    BINDINGS = [
-        b
-        for b in TextArea.BINDINGS
-        if (
-            "ctrl+h" not in b.key
-            and "ctrl+k" not in b.key
-            and "ctrl+m" not in b.key
-            and "ctrl+w" not in b.key
-        )
-    ]
-
-    def _on_key(self, event: events.Key) -> None:
-        """Handle key events for the note area.
-
-        This override removes the ``Ctrl+H``, ``Ctrl+K``, ``Ctrl+M`` and ``Ctrl+W``
-        shortcuts so they don't trigger Textual's default behaviours. All
-        other keys are passed through to ``TextArea`` for normal processing.
-        """
-
-        # Check for the control key combinations we want to ignore.
-        if event.key in {"ctrl+h", "ctrl+k", "ctrl+m", "ctrl+w"}:
-            # Ignore these shortcuts entirely
-            event.stop()
-            return
-        if event.key == "ctrl+delete":
-            # Trigger the deletion prompt instead of deleting text
-            event.stop()
-            self.app.action_prompt_delete()
-            return
-
-        # Defer to the base ``TextArea`` implementation for everything else
-        # to keep all standard text editing features intact.
-
-        # Defer to Textual's TextArea for all other key handling.
-        super()._on_key(event)
 
 
 class TimerOptionList(OptionList):
@@ -704,10 +678,10 @@ class NoteApp(App[None]):
         self.unsaved_map: dict[str, bool] = {}
         # Map tab id to file path (None for new unsaved files)
         self.file_map: dict[str, Path | None] = {}
-        # Keep a reference to each NoteTextArea widget by tab id so we can
+        # Keep a reference to each NoteEditor widget by tab id so we can
         # reliably focus them without querying, which may fail before the
         # widgets are fully mounted.
-        self.textareas: dict[str, NoteTextArea] = {}
+        self.textareas: dict[str, NoteEditor] = {}
         # Counter for generating unique tab ids
         self.tab_counter = 2
         # Track when Ctrl+S was last pressed to support rename on double press
@@ -781,7 +755,7 @@ class NoteApp(App[None]):
                             text = f.read()
                     except FileNotFoundError:
                         pass
-                note_area = NoteTextArea(text=text, classes="notes")
+                note_area = NoteEditor(text=text, classes="notes")
                 pane = TabPane(title, note_area, id=tab_id)
                 self.tabs.add_pane(pane)
                 self.file_map[tab_id] = path
@@ -800,7 +774,7 @@ class NoteApp(App[None]):
                 if path.exists():
                     with path.open("r", encoding="utf-8") as f:
                         text = f.read()
-                note_area = NoteTextArea(text=text, classes="notes")
+                note_area = NoteEditor(text=text, classes="notes")
                 pane = TabPane(f"Note {tab_id[-1]}", note_area, id=tab_id)
                 self.tabs.add_pane(pane)
                 self.unsaved_map[tab_id] = False
@@ -1006,7 +980,7 @@ class NoteApp(App[None]):
         tab_id = f"tab{self.tab_counter}"
         # Name new tabs by creation time without seconds but with day and month
         timestamp = datetime.now().strftime("%H%M-%d%m")
-        note_area = NoteTextArea(classes="notes")
+        note_area = NoteEditor(classes="notes")
         pane = TabPane(f"Note {timestamp}", note_area, id=tab_id)
         self.tabs.add_pane(pane)
         self.file_map[tab_id] = None
@@ -1046,7 +1020,7 @@ class NoteApp(App[None]):
         self.tab_counter += 1
         tab_id = f"tab{self.tab_counter}"
         # Create the text area separately to focus it after adding the pane.
-        note_area = NoteTextArea(text=text, classes="notes")
+        note_area = NoteEditor(text=text, classes="notes")
         # Use the base file name for the tab label
         pane = TabPane(path.stem, note_area, id=tab_id)
         self.tabs.add_pane(pane)
@@ -1256,7 +1230,7 @@ class NoteApp(App[None]):
         self.quote_request_times.append(time.time())
         self.action_show_quote()
 
-    def on_text_area_changed(self, event: TextArea.Changed) -> None:  # type: ignore[override]
+    def on_text_area_changed(self, event: NoteEditor.Changed) -> None:  # type: ignore[override]
         # Mark the current tab as modified when its content changes.
         active = self.tabs.active or "tab1"
         self.unsaved_map[active] = True

--- a/prompt_editor.py
+++ b/prompt_editor.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+"""Custom text editor built on prompt_toolkit."""
+
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.document import Document
+from prompt_toolkit.clipboard import InMemoryClipboard
+
+from textual.widget import Widget
+from textual import events
+from textual.message import Message
+from rich.text import Text
+
+
+class NoteEditor(Widget):
+    """A minimal multi-line text editor using *prompt_toolkit* buffers."""
+
+    DEFAULT_CSS = "NoteEditor {border: none;}"
+
+    # Allow the editor to take keyboard focus so it receives key events.
+    can_focus = True
+
+    class Changed(Message):
+        """Posted when the text content changes."""
+        def __init__(self, sender: "NoteEditor") -> None:
+            self.sender = sender
+            super().__init__()
+
+    def __init__(self, text: str = "", **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._clipboard = InMemoryClipboard()
+        self._buffer = Buffer(document=Document(text, len(text)), multiline=True)
+        self.cursor_blink = True
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Refresh when the widget size changes to keep wrapping accurate."""
+        self.refresh()
+
+
+    def _copy(self, event: object) -> None:
+        if data := self._buffer.copy_selection():
+            # ``copy_selection`` already returns ``ClipboardData``
+            # so it can be stored directly on the clipboard.
+            self._clipboard.set_data(data)
+
+    def _paste(self, event: object) -> None:
+        if data := self._clipboard.get_data():
+            self._buffer.paste_clipboard_data(data)
+
+    def _cut(self, event: object) -> None:
+        if data := self._buffer.cut_selection():
+            self._clipboard.set_data(data)
+
+    def _undo(self, event: object) -> None:
+        self._buffer.undo()
+
+    def _redo(self, event: object) -> None:
+        self._buffer.redo()
+
+    async def _on_key(self, event: events.Key) -> None:
+        """Translate key presses to buffer operations."""
+        key = event.key.lower()
+
+        # Cursor movement and editing commands handled here
+        if key == "left":
+            self._buffer.cursor_left()
+        elif key == "right":
+            self._buffer.cursor_right()
+        elif key == "up":
+            self._buffer.cursor_up()
+        elif key == "down":
+            self._buffer.cursor_down()
+        elif key == "backspace":
+            self._buffer.delete_before_cursor(1)
+        elif key == "delete":
+            self._buffer.delete()
+        elif key == "ctrl+c":
+            self._copy(None)
+        elif key == "ctrl+v":
+            self._paste(None)
+        elif key == "ctrl+x":
+            self._cut(None)
+        elif key == "ctrl+z":
+            self._undo(None)
+        elif key == "ctrl+y":
+            self._redo(None)
+        elif key in {"enter", "return"}:
+            self._buffer.insert_text("\n")
+        elif (
+            event.character
+            and not key.startswith("ctrl+")
+            and not key.startswith("meta+")
+            and not key.startswith("alt+")
+        ):
+            self._buffer.insert_text(event.character)
+        else:
+            # Unhandled shortcuts propagate to the application
+            return
+
+        event.stop()
+        self.post_message(self.Changed(self))
+        self.refresh()
+
+
+    def get_text(self) -> str:
+        """Return the current text in the editor."""
+        return self._buffer.text
+
+    def set_text(self, value: str) -> None:
+        """Replace the current text with ``value``."""
+        self._buffer.document = Document(value, len(value))
+
+    # Provide ``text`` attribute compatibility with the former TextArea widget.
+    @property
+    def text(self) -> str:  # pragma: no cover - simple getter
+        return self.get_text()
+
+    @text.setter
+    def text(self, value: str) -> None:  # pragma: no cover - simple setter
+        self.set_text(value)
+
+    def render(self) -> Text:
+        """Render the buffer with a visible cursor and word wrapping."""
+        width = max(1, self.size.width)
+        doc = self._buffer.document
+        text = doc.text
+        cursor = doc.cursor_position
+
+        lines: list[str] = []
+        current = ""
+        col = 0
+        last_space = -1
+
+        for i, ch in enumerate(text):
+            if i == cursor:
+                current += "▍"
+            if ch == "\n":
+                lines.append(current)
+                current = ""
+                col = 0
+                last_space = -1
+                continue
+            current += ch
+            col += 1
+            if ch.isspace():
+                last_space = len(current)
+            if col >= width:
+                if last_space != -1 and last_space != len(current):
+                    lines.append(current[:last_space])
+                    current = current[last_space:]
+                    col = len(current)
+                else:
+                    lines.append(current)
+                    current = ""
+                    col = 0
+                last_space = -1
+
+        if cursor == len(text):
+            current += "▍"
+        lines.append(current)
+        if not lines:
+            lines.append("▍")
+
+        return Text("\n".join(lines))


### PR DESCRIPTION
## Summary
- refine key handling to ignore unrelated shortcuts
- correct soft wrapping so cursor stays visible when lines wrap

## Testing
- `python -m py_compile main.py prompt_editor.py`
- `timeout 2 python main.py` *(fails: missing textual dependency)*

------
https://chatgpt.com/codex/tasks/task_e_686dd9269ed88328a700e9d65c3ca288